### PR TITLE
Update New-PasswordStatePassword.ps1 password conversion

### DIFF
--- a/PasswordState/Public/New-PasswordStatePassword.ps1
+++ b/PasswordState/Public/New-PasswordStatePassword.ps1
@@ -102,7 +102,7 @@ function New-PasswordStatePassword {
 
     if ($null -ne $Password) {
         $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)
-        $unsecurePassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+        $unsecurePassword = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($BSTR)
         $request | Add-Member -MemberType NoteProperty -Name Password -Value $unsecurePassword
     }
 


### PR DESCRIPTION
Modified password conversion to use PtrToStringBSTR instead of PtrToStringAuto for platform-independent compatibility.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!----->
The password conversion was using PtrToStringAuto, which is a platform-dependent method that may not work as expected on different operating systems. Modified it to use PtrToStringBSTR instead, which is a platform-independent method that works with BSTR strings.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.